### PR TITLE
Update README.md (Инструкции для докера)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,5 +41,5 @@ npx playwright install
 
 ```
 docker build -t prod-task-2-tests .
-docker run -it --rm -v $(pwd)/test-results:/test-results prod-task-2-tests
+docker run -it --rm -v "$(pwd)/test-results:/test-results" prod-task-2-tests
 ```


### PR DESCRIPTION
Если писать путь к папке docker run -it --rm -v $(pwd)/test-results:/test-results prod-task-2-tests без кавычек, то будет ошибка: docker: invalid reference format.

Правильная версия с кавычками в области пути к папке: docker run -it --rm -v "$(pwd)/test-results:/test-results" prod-task-2-tests